### PR TITLE
Prepare for release v2023.10.30-rc.0

### DIFF
--- a/charts/kubestash-operator/Chart.yaml
+++ b/charts/kubestash-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeStash, Kubernetes native backup operator by AppsCode
 name: kubestash-operator
-version: v0.1.0
-appVersion: v0.1.0
+version: v0.2.0-rc.0
+appVersion: v0.2.0-rc.0
 home: https://kubestash.com/
 icon: https://cdn.appscode.com/images/products/stash/kubestash-operator-icon.png
 sources:

--- a/charts/kubestash-operator/README.md
+++ b/charts/kubestash-operator/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash-operator --version=v0.1.0
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.1.0
+$ helm search repo appscode/kubestash-operator --version=v0.2.0-rc.0
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.2.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeStash operator on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubestash-operator`:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.1.0
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.2.0-rc.0
 ```
 
 The command deploys KubeStash operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -52,8 +52,8 @@ The following table lists the configurable parameters of the `kubestash-operator
 | replicaCount                          | Number of stash operator replicas to create (only 1 is supported)                                                                                                                                                                                                                                                                                                              | <code>1</code>                                        |
 | license                               | License for the product. Get a license by following the steps from [here](https://stash.run/docs/latest/setup/install/enterprise#get-a-trial-license). <br> Example: <br> `helm install appscode/kubestash-operator \` <br> `--set-file license=/path/to/license/file` <br> `or` <br> `helm install appscode/kubestash-operator \` <br> `--set license=<license file content>` | <code>""</code>                                       |
 | licenseApiService                     | Name of the ApiService to use by the addon to identify the respective service and certificate for license verification request                                                                                                                                                                                                                                                 | <code>v1beta1.admission.kubestash.appscode.com</code> |
-| registryFQDN                          | Docker registry fqdn used to pull Stash related images. Set this to use docker registry hosted at ${registryFQDN}/${registry}/${image}                                                                                                                                                                                                                                         | <code>""</code>                                       |
-| operator.registry                     | Docker registry used to pull operator image                                                                                                                                                                                                                                                                                                                                    | <code>stashed</code>                                  |
+| registryFQDN                          | Docker registry fqdn used to pull Stash related images. Set this to use docker registry hosted at ${registryFQDN}/${registry}/${image}                                                                                                                                                                                                                                         | <code>ghcr.io</code>                                  |
+| operator.registry                     | Docker registry used to pull operator image                                                                                                                                                                                                                                                                                                                                    | <code>kubestash</code>                                |
 | operator.repository                   | Name of operator container image                                                                                                                                                                                                                                                                                                                                               | <code>kubestash</code>                                |
 | operator.tag                          | Operator container image tag                                                                                                                                                                                                                                                                                                                                                   | <code>v0.1.0</code>                                   |
 | operator.resources                    | Compute Resources required by the operator container                                                                                                                                                                                                                                                                                                                           | <code>{"requests":{"cpu":"100m"}}</code>              |
@@ -103,12 +103,12 @@ The following table lists the configurable parameters of the `kubestash-operator
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.1.0 --set replicaCount=1
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.2.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.1.0 --values values.yaml
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.2.0-rc.0 --values values.yaml
 ```

--- a/charts/kubestash-operator/values.yaml
+++ b/charts/kubestash-operator/values.yaml
@@ -21,10 +21,10 @@ license: ""
 licenseApiService: v1beta1.admission.kubestash.appscode.com
 # Docker registry fqdn used to pull Stash related images.
 # Set this to use docker registry hosted at ${registryFQDN}/${registry}/${image}
-registryFQDN: ""
+registryFQDN: ghcr.io
 operator:
   # Docker registry used to pull operator image
-  registry: stashed
+  registry: kubestash
   # Name of operator container image
   repository: kubestash
   # Operator container image tag

--- a/charts/kubestash/Chart.lock
+++ b/charts/kubestash/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kubestash-operator
   repository: file://../kubestash-operator
-  version: v0.1.0
-digest: sha256:c4fd83164fd1f639b057870a3f1e94fb4c39af1073ff0702ac03c68e070f5665
-generated: "2022-01-12T19:23:39.125139122+06:00"
+  version: v0.2.0-rc.0
+digest: sha256:9b3592b0bb0a0f0f124b59a1738ef199fd26ae5527e4182f72d9dfe497965ce7
+generated: "2023-10-29T22:33:11.631770755Z"

--- a/charts/kubestash/Chart.yaml
+++ b/charts/kubestash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: KubeStash by AppsCode - Backup your Kubernetes native applications
 name: kubestash
 type: application
-version: v2023.04.14
-appVersion: v2023.04.14
+version: v2023.10.30-rc.0
+appVersion: v2023.10.30-rc.0
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/kubestash/stash-icon.png
 sources:
@@ -14,4 +14,4 @@ maintainers:
 dependencies:
 - name: kubestash-operator
   repository: file://../kubestash-operator
-  version: v0.1.0
+  version: v0.2.0-rc.0

--- a/charts/kubestash/README.md
+++ b/charts/kubestash/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash --version=v2023.04.14
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2023.04.14
+$ helm search repo appscode/kubestash --version=v2023.10.30-rc.0
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2023.10.30-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys Backup operator on a [Kubernetes](http://kubernetes.io) clust
 To install/upgrade the chart with the release name `kubestash`:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2023.04.14
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2023.10.30-rc.0
 ```
 
 The command deploys Backup operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -58,12 +58,12 @@ The following table lists the configurable parameters of the `kubestash` chart a
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2023.04.14 --set global.registry=stashed
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2023.10.30-rc.0 --set global.registry=stashed
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2023.04.14 --values values.yaml
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2023.10.30-rc.0 --values values.yaml
 ```


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2023.10.30-rc.0
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/2
Signed-off-by: 1gtm <1gtm@appscode.com>