### PR TITLE
Prepare for release v2024.1.28-rc.2

### DIFF
--- a/catalog/raw/kubedump/kubedump-backup-function.yaml
+++ b/catalog/raw/kubedump/kubedump-backup-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --sanitize=${sanitize:=true}
   - --label-selector=${labelSelector:=}
   - --include-dependants=${includeDependants:=false}
-  image: ghcr.io/kubestash/kubedump:v0.3.0-rc.1
+  image: ghcr.io/kubestash/kubedump:v0.3.0-rc.2

--- a/catalog/raw/pvc/pvc-backup-function.yaml
+++ b/catalog/raw/pvc/pvc-backup-function.yaml
@@ -11,4 +11,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --paths=${paths:=}
-  image: ghcr.io/kubestash/pvc:v0.3.0-rc.1
+  image: ghcr.io/kubestash/pvc:v0.3.0-rc.2

--- a/catalog/raw/pvc/pvc-restore-function.yaml
+++ b/catalog/raw/pvc/pvc-restore-function.yaml
@@ -10,4 +10,4 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: ghcr.io/kubestash/pvc:v0.3.0-rc.1
+  image: ghcr.io/kubestash/pvc:v0.3.0-rc.2

--- a/catalog/raw/volumesnapshot/volumesnapshot-backup-function.yaml
+++ b/catalog/raw/volumesnapshot/volumesnapshot-backup-function.yaml
@@ -8,4 +8,4 @@ spec:
   - --namespace=${namespace:=default}
   - --backupsession=${backupSession:=}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
-  image: ghcr.io/kubestash/volume-snapshotter:v0.3.0-rc.1
+  image: ghcr.io/kubestash/volume-snapshotter:v0.3.0-rc.2

--- a/catalog/raw/volumesnapshot/volumesnapshot-restore-function.yaml
+++ b/catalog/raw/volumesnapshot/volumesnapshot-restore-function.yaml
@@ -9,4 +9,4 @@ spec:
   - --restoresession=${restoreSession:=}
   - --snapshot=${snapshot:=}
   - --task-name=${taskName:=}
-  image: ghcr.io/kubestash/volume-snapshotter:v0.3.0-rc.1
+  image: ghcr.io/kubestash/volume-snapshotter:v0.3.0-rc.2

--- a/catalog/raw/workload/workload-backup-function.yaml
+++ b/catalog/raw/workload/workload-backup-function.yaml
@@ -11,4 +11,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --paths=${paths:=}
   - --exclude=${exclude:=}
-  image: ghcr.io/kubestash/workload:v0.3.0-rc.1
+  image: ghcr.io/kubestash/workload:v0.3.0-rc.2

--- a/catalog/raw/workload/workload-restore-function.yaml
+++ b/catalog/raw/workload/workload-restore-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --include=${include:=}
-  image: ghcr.io/kubestash/workload:v0.3.0-rc.1
+  image: ghcr.io/kubestash/workload:v0.3.0-rc.2

--- a/charts/kubestash-catalog/Chart.yaml
+++ b/charts/kubestash-catalog/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubestash-catalog
 description: KubeStash Catalog by AppsCode - Catalog of KubeStash Addons
 type: application
-version: v2024.1.26-rc.1
-appVersion: v2024.1.26-rc.1
+version: v2024.1.28-rc.2
+appVersion: v2024.1.28-rc.2
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/kubestash-catalog/README.md
+++ b/charts/kubestash-catalog/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash-catalog --version=v2024.1.26-rc.1
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n stash --create-namespace --version=v2024.1.26-rc.1
+$ helm search repo appscode/kubestash-catalog --version=v2024.1.28-rc.2
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n stash --create-namespace --version=v2024.1.28-rc.2
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys Stash catalog on a [Kubernetes](http://kubernetes.io) cluster
 To install/upgrade the chart with the release name `kubestash-catalog`:
 
 ```bash
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n stash --create-namespace --version=v2024.1.26-rc.1
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n stash --create-namespace --version=v2024.1.28-rc.2
 ```
 
 The command deploys Stash catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -61,12 +61,12 @@ The following table lists the configurable parameters of the `kubestash-catalog`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n stash --create-namespace --version=v2024.1.26-rc.1 --set proxies.ghcr=ghcr.io
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n stash --create-namespace --version=v2024.1.28-rc.2 --set proxies.ghcr=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n stash --create-namespace --version=v2024.1.26-rc.1 --values values.yaml
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n stash --create-namespace --version=v2024.1.28-rc.2 --values values.yaml
 ```

--- a/charts/kubestash-catalog/templates/kubedump/kubedump-backup.yaml
+++ b/charts/kubestash-catalog/templates/kubedump/kubedump-backup.yaml
@@ -15,6 +15,6 @@ spec:
   - --sanitize=${sanitize:=true}
   - --label-selector=${labelSelector:=}
   - --include-dependants=${includeDependants:=false}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/kubedump") $) }}:v0.3.0-rc.1'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/kubedump") $) }}:v0.3.0-rc.2'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/pvc/pvc-backup.yaml
+++ b/charts/kubestash-catalog/templates/pvc/pvc-backup.yaml
@@ -14,6 +14,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --paths=${paths:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.3.0-rc.1'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.3.0-rc.2'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/pvc/pvc-restore.yaml
+++ b/charts/kubestash-catalog/templates/pvc/pvc-restore.yaml
@@ -13,6 +13,6 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.3.0-rc.1'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.3.0-rc.2'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-backup.yaml
+++ b/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-backup.yaml
@@ -12,6 +12,6 @@ spec:
   - --backupsession=${backupSession:=}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
   image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/volume-snapshotter")
-    $) }}:v0.3.0-rc.1'
+    $) }}:v0.3.0-rc.2'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-restore.yaml
+++ b/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-restore.yaml
@@ -13,6 +13,6 @@ spec:
   - --snapshot=${snapshot:=}
   - --task-name=${taskName:=}
   image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/volume-snapshotter")
-    $) }}:v0.3.0-rc.1'
+    $) }}:v0.3.0-rc.2'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/workload/workload-backup.yaml
+++ b/charts/kubestash-catalog/templates/workload/workload-backup.yaml
@@ -14,6 +14,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --paths=${paths:=}
   - --exclude=${exclude:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.3.0-rc.1'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.3.0-rc.2'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/workload/workload-restore.yaml
+++ b/charts/kubestash-catalog/templates/workload/workload-restore.yaml
@@ -15,6 +15,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --include=${include:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.3.0-rc.1'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.3.0-rc.2'
 {{ end }}
 

--- a/charts/kubestash-operator/Chart.yaml
+++ b/charts/kubestash-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeStash, Kubernetes native backup operator by AppsCode
 name: kubestash-operator
-version: v0.4.0-rc.1
-appVersion: v0.4.0-rc.1
+version: v0.4.0-rc.2
+appVersion: v0.4.0-rc.2
 home: https://kubestash.com/
 icon: https://cdn.appscode.com/images/products/stash/kubestash-operator-icon.png
 sources:

--- a/charts/kubestash-operator/README.md
+++ b/charts/kubestash-operator/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash-operator --version=v0.4.0-rc.1
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.4.0-rc.1
+$ helm search repo appscode/kubestash-operator --version=v0.4.0-rc.2
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.4.0-rc.2
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeStash operator on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubestash-operator`:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.4.0-rc.1
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.4.0-rc.2
 ```
 
 The command deploys KubeStash operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -108,12 +108,12 @@ The following table lists the configurable parameters of the `kubestash-operator
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.4.0-rc.1 --set replicaCount=1
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.4.0-rc.2 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.4.0-rc.1 --values values.yaml
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.4.0-rc.2 --values values.yaml
 ```

--- a/charts/kubestash/Chart.lock
+++ b/charts/kubestash/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kubestash-operator
   repository: file://../kubestash-operator
-  version: v0.4.0-rc.1
+  version: v0.4.0-rc.2
 - name: kubestash-catalog
   repository: file://../kubestash-catalog
-  version: v2024.1.26-rc.1
-digest: sha256:ac4b29be196f8e4b2ab5e3a656f4e356987dca08c228941f5c6469534fb5fd58
-generated: "2024-01-27T01:59:38.799216444Z"
+  version: v2024.1.28-rc.2
+digest: sha256:3f331796051c70e17da6d9224a1102de5bf5c1b849e275284b9e043bae5ddd81
+generated: "2024-01-28T12:01:16.801282789Z"

--- a/charts/kubestash/Chart.yaml
+++ b/charts/kubestash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: KubeStash by AppsCode - Backup your Kubernetes native applications
 name: kubestash
 type: application
-version: v2024.1.26-rc.1
-appVersion: v2024.1.26-rc.1
+version: v2024.1.28-rc.2
+appVersion: v2024.1.28-rc.2
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/kubestash/stash-icon.png
 sources:
@@ -14,7 +14,7 @@ maintainers:
 dependencies:
 - name: kubestash-operator
   repository: file://../kubestash-operator
-  version: v0.4.0-rc.1
+  version: v0.4.0-rc.2
 - name: kubestash-catalog
   repository: file://../kubestash-catalog
-  version: v2024.1.26-rc.1
+  version: v2024.1.28-rc.2

--- a/charts/kubestash/README.md
+++ b/charts/kubestash/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash --version=v2024.1.26-rc.1
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2024.1.26-rc.1
+$ helm search repo appscode/kubestash --version=v2024.1.28-rc.2
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2024.1.28-rc.2
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys Backup operator on a [Kubernetes](http://kubernetes.io) clust
 To install/upgrade the chart with the release name `kubestash`:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2024.1.26-rc.1
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2024.1.28-rc.2
 ```
 
 The command deploys Backup operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -58,12 +58,12 @@ The following table lists the configurable parameters of the `kubestash` chart a
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2024.1.26-rc.1 --set global.registry=stashed
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2024.1.28-rc.2 --set global.registry=stashed
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2024.1.26-rc.1 --values values.yaml
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2024.1.28-rc.2 --values values.yaml
 ```


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2024.1.28-rc.2
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/8
Signed-off-by: 1gtm <1gtm@appscode.com>