### PR TITLE
Prepare for release v2025.2.6-rc.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ lint: $(BUILD_DIRS)
 	    --env GO111MODULE=on                                    \
 	    --env GOFLAGS="-mod=vendor"                             \
 	    $(BUILD_IMAGE)                                          \
-	    golangci-lint run --enable $(ADDTL_LINTERS) --timeout=10m --skip-files="generated.*\.go$\" --skip-dirs-use-default --skip-dirs=client,vendor
+	    golangci-lint run --enable $(ADDTL_LINTERS) --timeout=10m --exclude-files="generated.*\.go$\" --exclude-dirs-use-default --exclude-dirs=client,vendor
 
 $(BUILD_DIRS):
 	@mkdir -p $@

--- a/catalog/copy-images.sh
+++ b/catalog/copy-images.sh
@@ -37,9 +37,9 @@ CMD="./crane"
 
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode/kube-rbac-proxy:v0.15.0 $IMAGE_REGISTRY/appscode/kube-rbac-proxy:v0.15.0
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode/kubectl:v1.31 $IMAGE_REGISTRY/appscode/kubectl:v1.31
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubedump:v0.14.0 $IMAGE_REGISTRY/kubestash/kubedump:v0.14.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubestash:v0.15.0 $IMAGE_REGISTRY/kubestash/kubestash:v0.15.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/manifest:v0.7.0 $IMAGE_REGISTRY/kubestash/manifest:v0.7.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/pvc:v0.14.0 $IMAGE_REGISTRY/kubestash/pvc:v0.14.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/volume-snapshotter:v0.14.0 $IMAGE_REGISTRY/kubestash/volume-snapshotter:v0.14.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/workload:v0.14.0 $IMAGE_REGISTRY/kubestash/workload:v0.14.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubedump:v0.15.0-rc.0 $IMAGE_REGISTRY/kubestash/kubedump:v0.15.0-rc.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubestash:v0.16.0-rc.0 $IMAGE_REGISTRY/kubestash/kubestash:v0.16.0-rc.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/manifest:v0.8.0-rc.0 $IMAGE_REGISTRY/kubestash/manifest:v0.8.0-rc.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/pvc:v0.15.0-rc.0 $IMAGE_REGISTRY/kubestash/pvc:v0.15.0-rc.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/volume-snapshotter:v0.15.0-rc.0 $IMAGE_REGISTRY/kubestash/volume-snapshotter:v0.15.0-rc.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/workload:v0.15.0-rc.0 $IMAGE_REGISTRY/kubestash/workload:v0.15.0-rc.0

--- a/catalog/export-images.sh
+++ b/catalog/export-images.sh
@@ -34,11 +34,11 @@ CMD="./images/crane"
 
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode/kube-rbac-proxy:v0.15.0 images/appscode-kube-rbac-proxy-v0.15.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode/kubectl:v1.31 images/appscode-kubectl-v1.31.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubedump:v0.14.0 images/kubestash-kubedump-v0.14.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubestash:v0.15.0 images/kubestash-kubestash-v0.15.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/manifest:v0.7.0 images/kubestash-manifest-v0.7.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/pvc:v0.14.0 images/kubestash-pvc-v0.14.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/volume-snapshotter:v0.14.0 images/kubestash-volume-snapshotter-v0.14.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/workload:v0.14.0 images/kubestash-workload-v0.14.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubedump:v0.15.0-rc.0 images/kubestash-kubedump-v0.15.0-rc.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubestash:v0.16.0-rc.0 images/kubestash-kubestash-v0.16.0-rc.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/manifest:v0.8.0-rc.0 images/kubestash-manifest-v0.8.0-rc.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/pvc:v0.15.0-rc.0 images/kubestash-pvc-v0.15.0-rc.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/volume-snapshotter:v0.15.0-rc.0 images/kubestash-volume-snapshotter-v0.15.0-rc.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/workload:v0.15.0-rc.0 images/kubestash-workload-v0.15.0-rc.0.tar
 
 tar -czvf images.tar.gz images

--- a/catalog/imagelist.yaml
+++ b/catalog/imagelist.yaml
@@ -1,8 +1,8 @@
 - ghcr.io/appscode/kube-rbac-proxy:v0.15.0
 - ghcr.io/appscode/kubectl:v1.31
-- ghcr.io/kubestash/kubedump:v0.14.0
-- ghcr.io/kubestash/kubestash:v0.15.0
-- ghcr.io/kubestash/manifest:v0.7.0
-- ghcr.io/kubestash/pvc:v0.14.0
-- ghcr.io/kubestash/volume-snapshotter:v0.14.0
-- ghcr.io/kubestash/workload:v0.14.0
+- ghcr.io/kubestash/kubedump:v0.15.0-rc.0
+- ghcr.io/kubestash/kubestash:v0.16.0-rc.0
+- ghcr.io/kubestash/manifest:v0.8.0-rc.0
+- ghcr.io/kubestash/pvc:v0.15.0-rc.0
+- ghcr.io/kubestash/volume-snapshotter:v0.15.0-rc.0
+- ghcr.io/kubestash/workload:v0.15.0-rc.0

--- a/catalog/import-images.sh
+++ b/catalog/import-images.sh
@@ -28,9 +28,9 @@ CMD="./crane"
 
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-kube-rbac-proxy-v0.15.0.tar $IMAGE_REGISTRY/appscode/kube-rbac-proxy:v0.15.0
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-kubectl-v1.31.tar $IMAGE_REGISTRY/appscode/kubectl:v1.31
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-kubedump-v0.14.0.tar $IMAGE_REGISTRY/kubestash/kubedump:v0.14.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-kubestash-v0.15.0.tar $IMAGE_REGISTRY/kubestash/kubestash:v0.15.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-manifest-v0.7.0.tar $IMAGE_REGISTRY/kubestash/manifest:v0.7.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-pvc-v0.14.0.tar $IMAGE_REGISTRY/kubestash/pvc:v0.14.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-volume-snapshotter-v0.14.0.tar $IMAGE_REGISTRY/kubestash/volume-snapshotter:v0.14.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-workload-v0.14.0.tar $IMAGE_REGISTRY/kubestash/workload:v0.14.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-kubedump-v0.15.0-rc.0.tar $IMAGE_REGISTRY/kubestash/kubedump:v0.15.0-rc.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-kubestash-v0.16.0-rc.0.tar $IMAGE_REGISTRY/kubestash/kubestash:v0.16.0-rc.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-manifest-v0.8.0-rc.0.tar $IMAGE_REGISTRY/kubestash/manifest:v0.8.0-rc.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-pvc-v0.15.0-rc.0.tar $IMAGE_REGISTRY/kubestash/pvc:v0.15.0-rc.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-volume-snapshotter-v0.15.0-rc.0.tar $IMAGE_REGISTRY/kubestash/volume-snapshotter:v0.15.0-rc.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-workload-v0.15.0-rc.0.tar $IMAGE_REGISTRY/kubestash/workload:v0.15.0-rc.0

--- a/catalog/import-into-k3s.sh
+++ b/catalog/import-into-k3s.sh
@@ -26,9 +26,9 @@ tar -zxvf $TARBALL
 
 k3s ctr images import images/appscode-kube-rbac-proxy-v0.15.0.tar
 k3s ctr images import images/appscode-kubectl-v1.31.tar
-k3s ctr images import images/kubestash-kubedump-v0.14.0.tar
-k3s ctr images import images/kubestash-kubestash-v0.15.0.tar
-k3s ctr images import images/kubestash-manifest-v0.7.0.tar
-k3s ctr images import images/kubestash-pvc-v0.14.0.tar
-k3s ctr images import images/kubestash-volume-snapshotter-v0.14.0.tar
-k3s ctr images import images/kubestash-workload-v0.14.0.tar
+k3s ctr images import images/kubestash-kubedump-v0.15.0-rc.0.tar
+k3s ctr images import images/kubestash-kubestash-v0.16.0-rc.0.tar
+k3s ctr images import images/kubestash-manifest-v0.8.0-rc.0.tar
+k3s ctr images import images/kubestash-pvc-v0.15.0-rc.0.tar
+k3s ctr images import images/kubestash-volume-snapshotter-v0.15.0-rc.0.tar
+k3s ctr images import images/kubestash-workload-v0.15.0-rc.0.tar

--- a/catalog/raw/kubedump/kubedump-backup-function.yaml
+++ b/catalog/raw/kubedump/kubedump-backup-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --sanitize=${sanitize:=true}
   - --label-selector=${labelSelector:=}
   - --include-dependants=${includeDependants:=false}
-  image: ghcr.io/kubestash/kubedump:v0.14.0
+  image: ghcr.io/kubestash/kubedump:v0.15.0-rc.0

--- a/catalog/raw/manifest/manifest-backup-function.yaml
+++ b/catalog/raw/manifest/manifest-backup-function.yaml
@@ -9,4 +9,4 @@ spec:
   - --backupsession=${backupSession:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: ghcr.io/kubestash/manifest:v0.7.0
+  image: ghcr.io/kubestash/manifest:v0.8.0-rc.0

--- a/catalog/raw/manifest/manifest-restore-function.yaml
+++ b/catalog/raw/manifest/manifest-restore-function.yaml
@@ -10,4 +10,4 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: ghcr.io/kubestash/manifest:v0.7.0
+  image: ghcr.io/kubestash/manifest:v0.8.0-rc.0

--- a/catalog/raw/pvc/pvc-backup-function.yaml
+++ b/catalog/raw/pvc/pvc-backup-function.yaml
@@ -11,4 +11,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --paths=${paths:=}
-  image: ghcr.io/kubestash/pvc:v0.14.0
+  image: ghcr.io/kubestash/pvc:v0.15.0-rc.0

--- a/catalog/raw/pvc/pvc-restore-function.yaml
+++ b/catalog/raw/pvc/pvc-restore-function.yaml
@@ -10,4 +10,4 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: ghcr.io/kubestash/pvc:v0.14.0
+  image: ghcr.io/kubestash/pvc:v0.15.0-rc.0

--- a/catalog/raw/volumesnapshot/volumesnapshot-backup-function.yaml
+++ b/catalog/raw/volumesnapshot/volumesnapshot-backup-function.yaml
@@ -8,4 +8,4 @@ spec:
   - --namespace=${namespace:=default}
   - --backupsession=${backupSession:=}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
-  image: ghcr.io/kubestash/volume-snapshotter:v0.14.0
+  image: ghcr.io/kubestash/volume-snapshotter:v0.15.0-rc.0

--- a/catalog/raw/volumesnapshot/volumesnapshot-restore-function.yaml
+++ b/catalog/raw/volumesnapshot/volumesnapshot-restore-function.yaml
@@ -9,4 +9,4 @@ spec:
   - --restoresession=${restoreSession:=}
   - --snapshot=${snapshot:=}
   - --task-name=${taskName:=}
-  image: ghcr.io/kubestash/volume-snapshotter:v0.14.0
+  image: ghcr.io/kubestash/volume-snapshotter:v0.15.0-rc.0

--- a/catalog/raw/workload/workload-backup-function.yaml
+++ b/catalog/raw/workload/workload-backup-function.yaml
@@ -11,4 +11,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --paths=${paths:=}
   - --exclude=${exclude:=}
-  image: ghcr.io/kubestash/workload:v0.14.0
+  image: ghcr.io/kubestash/workload:v0.15.0-rc.0

--- a/catalog/raw/workload/workload-restore-function.yaml
+++ b/catalog/raw/workload/workload-restore-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --include=${include:=}
-  image: ghcr.io/kubestash/workload:v0.14.0
+  image: ghcr.io/kubestash/workload:v0.15.0-rc.0

--- a/charts/kubestash-catalog/Chart.yaml
+++ b/charts/kubestash-catalog/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubestash-catalog
 description: KubeStash Catalog by AppsCode - Catalog of KubeStash Addons
 type: application
-version: v2025.1.9
-appVersion: v2025.1.9
+version: v2025.2.6-rc.0
+appVersion: v2025.2.6-rc.0
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/kubestash-catalog/README.md
+++ b/charts/kubestash-catalog/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash-catalog --version=v2025.1.9
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.1.9
+$ helm search repo appscode/kubestash-catalog --version=v2025.2.6-rc.0
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.2.6-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeStash catalog on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `kubestash-catalog`:
 
 ```bash
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.1.9
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.2.6-rc.0
 ```
 
 The command deploys KubeStash catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -62,12 +62,12 @@ The following table lists the configurable parameters of the `kubestash-catalog`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.1.9 --set proxies.ghcr=ghcr.io
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.2.6-rc.0 --set proxies.ghcr=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.1.9 --values values.yaml
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.2.6-rc.0 --values values.yaml
 ```

--- a/charts/kubestash-catalog/templates/kubedump/kubedump-backup.yaml
+++ b/charts/kubestash-catalog/templates/kubedump/kubedump-backup.yaml
@@ -15,6 +15,6 @@ spec:
   - --sanitize=${sanitize:=true}
   - --label-selector=${labelSelector:=}
   - --include-dependants=${includeDependants:=false}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/kubedump") $) }}:v0.14.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/kubedump") $) }}:v0.15.0-rc.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/manifest/manifest-backup.yaml
+++ b/charts/kubestash-catalog/templates/manifest/manifest-backup.yaml
@@ -12,6 +12,6 @@ spec:
   - --backupsession=${backupSession:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/manifest") $) }}:v0.7.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/manifest") $) }}:v0.8.0-rc.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/manifest/manifest-restore.yaml
+++ b/charts/kubestash-catalog/templates/manifest/manifest-restore.yaml
@@ -13,6 +13,6 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/manifest") $) }}:v0.7.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/manifest") $) }}:v0.8.0-rc.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/pvc/pvc-backup.yaml
+++ b/charts/kubestash-catalog/templates/pvc/pvc-backup.yaml
@@ -14,6 +14,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --paths=${paths:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.14.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.15.0-rc.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/pvc/pvc-restore.yaml
+++ b/charts/kubestash-catalog/templates/pvc/pvc-restore.yaml
@@ -13,6 +13,6 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.14.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.15.0-rc.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-backup.yaml
+++ b/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-backup.yaml
@@ -12,6 +12,6 @@ spec:
   - --backupsession=${backupSession:=}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
   image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/volume-snapshotter")
-    $) }}:v0.14.0'
+    $) }}:v0.15.0-rc.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-restore.yaml
+++ b/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-restore.yaml
@@ -13,6 +13,6 @@ spec:
   - --snapshot=${snapshot:=}
   - --task-name=${taskName:=}
   image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/volume-snapshotter")
-    $) }}:v0.14.0'
+    $) }}:v0.15.0-rc.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/workload/workload-backup.yaml
+++ b/charts/kubestash-catalog/templates/workload/workload-backup.yaml
@@ -14,6 +14,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --paths=${paths:=}
   - --exclude=${exclude:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.14.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.15.0-rc.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/workload/workload-restore.yaml
+++ b/charts/kubestash-catalog/templates/workload/workload-restore.yaml
@@ -15,6 +15,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --include=${include:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.14.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.15.0-rc.0'
 {{ end }}
 

--- a/charts/kubestash-metrics/Chart.yaml
+++ b/charts/kubestash-metrics/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubestash-metrics
 description: KubeStash State Metrics
 type: application
-version: v2025.1.9
-appVersion: v2025.1.9
+version: v2025.2.6-rc.0
+appVersion: v2025.2.6-rc.0
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/kubestash-metrics/README.md
+++ b/charts/kubestash-metrics/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash-metrics --version=v2025.1.9
-$ helm upgrade -i kubestash-metrics appscode/kubestash-metrics -n kubestash --create-namespace --version=v2025.1.9
+$ helm search repo appscode/kubestash-metrics --version=v2025.2.6-rc.0
+$ helm upgrade -i kubestash-metrics appscode/kubestash-metrics -n kubestash --create-namespace --version=v2025.2.6-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeStash metrics configurations on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `kubestash-metrics`:
 
 ```bash
-$ helm upgrade -i kubestash-metrics appscode/kubestash-metrics -n kubestash --create-namespace --version=v2025.1.9
+$ helm upgrade -i kubestash-metrics appscode/kubestash-metrics -n kubestash --create-namespace --version=v2025.2.6-rc.0
 ```
 
 The command deploys KubeStash metrics configurations on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubestash-operator/Chart.yaml
+++ b/charts/kubestash-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeStash, Kubernetes native backup operator by AppsCode
 name: kubestash-operator
-version: v0.15.0
-appVersion: v0.15.0
+version: v0.16.0-rc.0
+appVersion: v0.16.0-rc.0
 home: https://kubestash.com/
 icon: https://cdn.appscode.com/images/products/stash/kubestash-operator-icon.png
 sources:

--- a/charts/kubestash-operator/README.md
+++ b/charts/kubestash-operator/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash-operator --version=v0.15.0
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.15.0
+$ helm search repo appscode/kubestash-operator --version=v0.16.0-rc.0
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.16.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeStash operator on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubestash-operator`:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.15.0
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.16.0-rc.0
 ```
 
 The command deploys KubeStash operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -113,12 +113,12 @@ The following table lists the configurable parameters of the `kubestash-operator
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.15.0 --set replicaCount=1
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.16.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.15.0 --values values.yaml
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.16.0-rc.0 --values values.yaml
 ```

--- a/charts/kubestash/Chart.lock
+++ b/charts/kubestash/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: kubestash-operator
   repository: file://../kubestash-operator
-  version: v0.15.0
+  version: v0.16.0-rc.0
 - name: kubestash-catalog
   repository: file://../kubestash-catalog
-  version: v2025.1.9
+  version: v2025.2.6-rc.0
 - name: kubestash-metrics
   repository: file://../kubestash-metrics
-  version: v2025.1.9
+  version: v2025.2.6-rc.0
 - name: ace-user-roles
   repository: oci://ghcr.io/appscode-charts
   version: v2024.9.30
-digest: sha256:2efd5094aa68886385acd23e7fc6c391863d7948f4c8cd59be14b9febf63836d
-generated: "2025-01-31T16:37:54.520779+06:00"
+digest: sha256:9b7960d68b7987931677446b851f9649a11a970da1327854642ef2331fb9a14b
+generated: "2025-02-06T21:22:54.10132661Z"

--- a/charts/kubestash/Chart.yaml
+++ b/charts/kubestash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: KubeStash by AppsCode - Backup your Kubernetes native applications
 name: kubestash
 type: application
-version: v2025.1.9
-appVersion: v2025.1.9
+version: v2025.2.6-rc.0
+appVersion: v2025.2.6-rc.0
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/kubestash/stash-icon.png
 sources:
@@ -15,15 +15,15 @@ dependencies:
 - name: kubestash-operator
   repository: file://../kubestash-operator
   condition: kubestash-operator.enabled
-  version: v0.15.0
+  version: v0.16.0-rc.0
 - name: kubestash-catalog
   repository: file://../kubestash-catalog
   condition: kubestash-catalog.enabled
-  version: v2025.1.9
+  version: v2025.2.6-rc.0
 - name: kubestash-metrics
   repository: file://../kubestash-metrics
   condition: kubestash-metrics.enabled
-  version: v2025.1.9
+  version: v2025.2.6-rc.0
 - name: ace-user-roles
   repository: oci://ghcr.io/appscode-charts
   condition: ace-user-roles.enabled

--- a/charts/kubestash/README.md
+++ b/charts/kubestash/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash --version=v2025.1.9
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.1.9
+$ helm search repo appscode/kubestash --version=v2025.2.6-rc.0
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.2.6-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys Backup operator on a [Kubernetes](http://kubernetes.io) clust
 To install/upgrade the chart with the release name `kubestash`:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.1.9
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.2.6-rc.0
 ```
 
 The command deploys Backup operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -74,12 +74,12 @@ The following table lists the configurable parameters of the `kubestash` chart a
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.1.9 --set global.registry=stashed
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.2.6-rc.0 --set global.registry=stashed
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.1.9 --values values.yaml
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.2.6-rc.0 --values values.yaml
 ```


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2025.2.6-rc.0
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/24
Signed-off-by: 1gtm <1gtm@appscode.com>