### PR TITLE
Prepare for release v2025.6.30

### DIFF
--- a/catalog/copy-images.sh
+++ b/catalog/copy-images.sh
@@ -37,8 +37,9 @@ CMD="./crane"
 
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/appscode/kubectl:v1.31 $IMAGE_REGISTRY/appscode/kubectl:v1.31
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubedump:v0.17.0 $IMAGE_REGISTRY/kubestash/kubedump:v0.17.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubestash:v0.18.0 $IMAGE_REGISTRY/kubestash/kubestash:v0.18.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/manifest:v0.10.0 $IMAGE_REGISTRY/kubestash/manifest:v0.10.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/pvc:v0.17.0 $IMAGE_REGISTRY/kubestash/pvc:v0.17.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/volume-snapshotter:v0.17.0 $IMAGE_REGISTRY/kubestash/volume-snapshotter:v0.17.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/workload:v0.17.0 $IMAGE_REGISTRY/kubestash/workload:v0.17.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubedump:v0.18.0 $IMAGE_REGISTRY/kubestash/kubedump:v0.18.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubestash:v0.19.0 $IMAGE_REGISTRY/kubestash/kubestash:v0.19.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/manifest:v0.11.0 $IMAGE_REGISTRY/kubestash/manifest:v0.11.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/pvc:v0.18.0 $IMAGE_REGISTRY/kubestash/pvc:v0.18.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/volume-snapshotter:v0.18.0 $IMAGE_REGISTRY/kubestash/volume-snapshotter:v0.18.0
+$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/workload:v0.18.0 $IMAGE_REGISTRY/kubestash/workload:v0.18.0

--- a/catalog/export-images.sh
+++ b/catalog/export-images.sh
@@ -34,10 +34,11 @@ CMD="./images/crane"
 
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/appscode/kubectl:v1.31 images/appscode-kubectl-v1.31.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubedump:v0.17.0 images/kubestash-kubedump-v0.17.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubestash:v0.18.0 images/kubestash-kubestash-v0.18.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/manifest:v0.10.0 images/kubestash-manifest-v0.10.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/pvc:v0.17.0 images/kubestash-pvc-v0.17.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/volume-snapshotter:v0.17.0 images/kubestash-volume-snapshotter-v0.17.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/workload:v0.17.0 images/kubestash-workload-v0.17.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubedump:v0.18.0 images/kubestash-kubedump-v0.18.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/kubestash:v0.19.0 images/kubestash-kubestash-v0.19.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/manifest:v0.11.0 images/kubestash-manifest-v0.11.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/pvc:v0.18.0 images/kubestash-pvc-v0.18.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/volume-snapshotter:v0.18.0 images/kubestash-volume-snapshotter-v0.18.0.tar
+$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubestash/workload:v0.18.0 images/kubestash-workload-v0.18.0.tar
 
 tar -czvf images.tar.gz images

--- a/catalog/imagelist.yaml
+++ b/catalog/imagelist.yaml
@@ -1,7 +1,8 @@
 - ghcr.io/appscode/kubectl:v1.31
 - ghcr.io/kubestash/kubedump:v0.17.0
-- ghcr.io/kubestash/kubestash:v0.18.0
-- ghcr.io/kubestash/manifest:v0.10.0
-- ghcr.io/kubestash/pvc:v0.17.0
-- ghcr.io/kubestash/volume-snapshotter:v0.17.0
-- ghcr.io/kubestash/workload:v0.17.0
+- ghcr.io/kubestash/kubedump:v0.18.0
+- ghcr.io/kubestash/kubestash:v0.19.0
+- ghcr.io/kubestash/manifest:v0.11.0
+- ghcr.io/kubestash/pvc:v0.18.0
+- ghcr.io/kubestash/volume-snapshotter:v0.18.0
+- ghcr.io/kubestash/workload:v0.18.0

--- a/catalog/import-images.sh
+++ b/catalog/import-images.sh
@@ -28,8 +28,9 @@ CMD="./crane"
 
 $CMD push --allow-nondistributable-artifacts --insecure images/appscode-kubectl-v1.31.tar $IMAGE_REGISTRY/appscode/kubectl:v1.31
 $CMD push --allow-nondistributable-artifacts --insecure images/kubestash-kubedump-v0.17.0.tar $IMAGE_REGISTRY/kubestash/kubedump:v0.17.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-kubestash-v0.18.0.tar $IMAGE_REGISTRY/kubestash/kubestash:v0.18.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-manifest-v0.10.0.tar $IMAGE_REGISTRY/kubestash/manifest:v0.10.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-pvc-v0.17.0.tar $IMAGE_REGISTRY/kubestash/pvc:v0.17.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-volume-snapshotter-v0.17.0.tar $IMAGE_REGISTRY/kubestash/volume-snapshotter:v0.17.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-workload-v0.17.0.tar $IMAGE_REGISTRY/kubestash/workload:v0.17.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-kubedump-v0.18.0.tar $IMAGE_REGISTRY/kubestash/kubedump:v0.18.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-kubestash-v0.19.0.tar $IMAGE_REGISTRY/kubestash/kubestash:v0.19.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-manifest-v0.11.0.tar $IMAGE_REGISTRY/kubestash/manifest:v0.11.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-pvc-v0.18.0.tar $IMAGE_REGISTRY/kubestash/pvc:v0.18.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-volume-snapshotter-v0.18.0.tar $IMAGE_REGISTRY/kubestash/volume-snapshotter:v0.18.0
+$CMD push --allow-nondistributable-artifacts --insecure images/kubestash-workload-v0.18.0.tar $IMAGE_REGISTRY/kubestash/workload:v0.18.0

--- a/catalog/import-into-k3s.sh
+++ b/catalog/import-into-k3s.sh
@@ -26,8 +26,9 @@ tar -zxvf $TARBALL
 
 k3s ctr images import images/appscode-kubectl-v1.31.tar
 k3s ctr images import images/kubestash-kubedump-v0.17.0.tar
-k3s ctr images import images/kubestash-kubestash-v0.18.0.tar
-k3s ctr images import images/kubestash-manifest-v0.10.0.tar
-k3s ctr images import images/kubestash-pvc-v0.17.0.tar
-k3s ctr images import images/kubestash-volume-snapshotter-v0.17.0.tar
-k3s ctr images import images/kubestash-workload-v0.17.0.tar
+k3s ctr images import images/kubestash-kubedump-v0.18.0.tar
+k3s ctr images import images/kubestash-kubestash-v0.19.0.tar
+k3s ctr images import images/kubestash-manifest-v0.11.0.tar
+k3s ctr images import images/kubestash-pvc-v0.18.0.tar
+k3s ctr images import images/kubestash-volume-snapshotter-v0.18.0.tar
+k3s ctr images import images/kubestash-workload-v0.18.0.tar

--- a/catalog/raw/kubedump/kubedump-backup-function.yaml
+++ b/catalog/raw/kubedump/kubedump-backup-function.yaml
@@ -16,4 +16,4 @@ spec:
   - --exclude-namespaces=${ExcludeNamespaces:=}
   - --include-resources=${IncludeResources:=}
   - --exclude-resources=${ExcludeResources:=}
-  image: ghcr.io/kubestash/kubedump:v0.17.0
+  image: ghcr.io/kubestash/kubedump:v0.18.0

--- a/catalog/raw/manifest/manifest-backup-function.yaml
+++ b/catalog/raw/manifest/manifest-backup-function.yaml
@@ -10,4 +10,4 @@ spec:
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
   - --include-rbac-resources=${includeRBACResources:=}
-  image: ghcr.io/kubestash/manifest:v0.10.0
+  image: ghcr.io/kubestash/manifest:v0.11.0

--- a/catalog/raw/manifest/manifest-restore-function.yaml
+++ b/catalog/raw/manifest/manifest-restore-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --include-rbac-resources=${includeRBACResources:=}
   - --override-resources=${overrideResources:=}
-  image: ghcr.io/kubestash/manifest:v0.10.0
+  image: ghcr.io/kubestash/manifest:v0.11.0

--- a/catalog/raw/pvc/pvc-backup-function.yaml
+++ b/catalog/raw/pvc/pvc-backup-function.yaml
@@ -11,4 +11,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --paths=${paths:=}
-  image: ghcr.io/kubestash/pvc:v0.17.0
+  image: ghcr.io/kubestash/pvc:v0.18.0

--- a/catalog/raw/pvc/pvc-restore-function.yaml
+++ b/catalog/raw/pvc/pvc-restore-function.yaml
@@ -10,4 +10,4 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: ghcr.io/kubestash/pvc:v0.17.0
+  image: ghcr.io/kubestash/pvc:v0.18.0

--- a/catalog/raw/volumesnapshot/volumesnapshot-backup-function.yaml
+++ b/catalog/raw/volumesnapshot/volumesnapshot-backup-function.yaml
@@ -8,4 +8,4 @@ spec:
   - --namespace=${namespace:=default}
   - --backupsession=${backupSession:=}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
-  image: ghcr.io/kubestash/volume-snapshotter:v0.17.0
+  image: ghcr.io/kubestash/volume-snapshotter:v0.18.0

--- a/catalog/raw/volumesnapshot/volumesnapshot-restore-function.yaml
+++ b/catalog/raw/volumesnapshot/volumesnapshot-restore-function.yaml
@@ -9,4 +9,4 @@ spec:
   - --restoresession=${restoreSession:=}
   - --snapshot=${snapshot:=}
   - --task-name=${taskName:=}
-  image: ghcr.io/kubestash/volume-snapshotter:v0.17.0
+  image: ghcr.io/kubestash/volume-snapshotter:v0.18.0

--- a/catalog/raw/workload/workload-backup-function.yaml
+++ b/catalog/raw/workload/workload-backup-function.yaml
@@ -11,4 +11,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --paths=${paths:=}
   - --exclude=${exclude:=}
-  image: ghcr.io/kubestash/workload:v0.17.0
+  image: ghcr.io/kubestash/workload:v0.18.0

--- a/catalog/raw/workload/workload-restore-function.yaml
+++ b/catalog/raw/workload/workload-restore-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --include=${include:=}
-  image: ghcr.io/kubestash/workload:v0.17.0
+  image: ghcr.io/kubestash/workload:v0.18.0

--- a/charts/kubestash-catalog/Chart.yaml
+++ b/charts/kubestash-catalog/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubestash-catalog
 description: KubeStash Catalog by AppsCode - Catalog of KubeStash Addons
 type: application
-version: v2025.4.30
-appVersion: v2025.4.30
+version: v2025.6.30
+appVersion: v2025.6.30
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/kubestash-catalog/README.md
+++ b/charts/kubestash-catalog/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash-catalog --version=v2025.4.30
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.4.30
+$ helm search repo appscode/kubestash-catalog --version=v2025.6.30
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.6.30
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeStash catalog on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `kubestash-catalog`:
 
 ```bash
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.4.30
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.6.30
 ```
 
 The command deploys KubeStash catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -62,12 +62,12 @@ The following table lists the configurable parameters of the `kubestash-catalog`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.4.30 --set proxies.ghcr=ghcr.io
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.6.30 --set proxies.ghcr=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.4.30 --values values.yaml
+$ helm upgrade -i kubestash-catalog appscode/kubestash-catalog -n kubestash --create-namespace --version=v2025.6.30 --values values.yaml
 ```

--- a/charts/kubestash-catalog/templates/kubedump/kubedump-backup.yaml
+++ b/charts/kubestash-catalog/templates/kubedump/kubedump-backup.yaml
@@ -19,6 +19,6 @@ spec:
   - --exclude-namespaces=${ExcludeNamespaces:=}
   - --include-resources=${IncludeResources:=}
   - --exclude-resources=${ExcludeResources:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/kubedump") $) }}:v0.17.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/kubedump") $) }}:v0.18.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/manifest/manifest-backup.yaml
+++ b/charts/kubestash-catalog/templates/manifest/manifest-backup.yaml
@@ -13,6 +13,6 @@ spec:
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
   - --include-rbac-resources=${includeRBACResources:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/manifest") $) }}:v0.10.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/manifest") $) }}:v0.11.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/manifest/manifest-restore.yaml
+++ b/charts/kubestash-catalog/templates/manifest/manifest-restore.yaml
@@ -15,6 +15,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --include-rbac-resources=${includeRBACResources:=}
   - --override-resources=${overrideResources:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/manifest") $) }}:v0.10.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/manifest") $) }}:v0.11.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/pvc/pvc-backup.yaml
+++ b/charts/kubestash-catalog/templates/pvc/pvc-backup.yaml
@@ -14,6 +14,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --paths=${paths:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.17.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.18.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/pvc/pvc-restore.yaml
+++ b/charts/kubestash-catalog/templates/pvc/pvc-restore.yaml
@@ -13,6 +13,6 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.17.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/pvc") $) }}:v0.18.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-backup.yaml
+++ b/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-backup.yaml
@@ -11,6 +11,6 @@ spec:
   - --namespace=${namespace:=default}
   - --backupsession=${backupSession:=}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/volume-snapshotter") $) }}:v0.17.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/volume-snapshotter") $) }}:v0.18.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-restore.yaml
+++ b/charts/kubestash-catalog/templates/volumesnapshot/volumesnapshot-restore.yaml
@@ -12,6 +12,6 @@ spec:
   - --restoresession=${restoreSession:=}
   - --snapshot=${snapshot:=}
   - --task-name=${taskName:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/volume-snapshotter") $) }}:v0.17.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/volume-snapshotter") $) }}:v0.18.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/workload/workload-backup.yaml
+++ b/charts/kubestash-catalog/templates/workload/workload-backup.yaml
@@ -14,6 +14,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --paths=${paths:=}
   - --exclude=${exclude:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.17.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.18.0'
 {{ end }}
 

--- a/charts/kubestash-catalog/templates/workload/workload-restore.yaml
+++ b/charts/kubestash-catalog/templates/workload/workload-restore.yaml
@@ -15,6 +15,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --exclude=${exclude:=}
   - --include=${include:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.17.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubestash/workload") $) }}:v0.18.0'
 {{ end }}
 

--- a/charts/kubestash-metrics/Chart.yaml
+++ b/charts/kubestash-metrics/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubestash-metrics
 description: KubeStash State Metrics
 type: application
-version: v2025.4.30
-appVersion: v2025.4.30
+version: v2025.6.30
+appVersion: v2025.6.30
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/kubestash-metrics/README.md
+++ b/charts/kubestash-metrics/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash-metrics --version=v2025.4.30
-$ helm upgrade -i kubestash-metrics appscode/kubestash-metrics -n kubestash --create-namespace --version=v2025.4.30
+$ helm search repo appscode/kubestash-metrics --version=v2025.6.30
+$ helm upgrade -i kubestash-metrics appscode/kubestash-metrics -n kubestash --create-namespace --version=v2025.6.30
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeStash metrics configurations on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `kubestash-metrics`:
 
 ```bash
-$ helm upgrade -i kubestash-metrics appscode/kubestash-metrics -n kubestash --create-namespace --version=v2025.4.30
+$ helm upgrade -i kubestash-metrics appscode/kubestash-metrics -n kubestash --create-namespace --version=v2025.6.30
 ```
 
 The command deploys KubeStash metrics configurations on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubestash-operator/Chart.yaml
+++ b/charts/kubestash-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeStash, Kubernetes native backup operator by AppsCode
 name: kubestash-operator
-version: v0.18.0
-appVersion: v0.18.0
+version: v0.19.0
+appVersion: v0.19.0
 home: https://kubestash.com/
 icon: https://cdn.appscode.com/images/products/stash/kubestash-operator-icon.png
 sources:

--- a/charts/kubestash-operator/README.md
+++ b/charts/kubestash-operator/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash-operator --version=v0.18.0
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.18.0
+$ helm search repo appscode/kubestash-operator --version=v0.19.0
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.19.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeStash operator on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubestash-operator`:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.18.0
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.19.0
 ```
 
 The command deploys KubeStash operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -110,12 +110,12 @@ The following table lists the configurable parameters of the `kubestash-operator
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.18.0 --set replicaCount=1
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.19.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.18.0 --values values.yaml
+$ helm upgrade -i kubestash-operator appscode/kubestash-operator -n kubestash --create-namespace --version=v0.19.0 --values values.yaml
 ```

--- a/charts/kubestash/Chart.lock
+++ b/charts/kubestash/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: kubestash-operator
   repository: file://../kubestash-operator
-  version: v0.18.0
+  version: v0.19.0
 - name: kubestash-catalog
   repository: file://../kubestash-catalog
-  version: v2025.4.30
+  version: v2025.6.30
 - name: kubestash-metrics
   repository: file://../kubestash-metrics
-  version: v2025.4.30
+  version: v2025.6.30
 - name: ace-user-roles
   repository: oci://ghcr.io/appscode-charts
   version: v2025.3.14
 - name: taskqueue
   repository: oci://ghcr.io/appscode-charts
   version: v2025.6.30
-digest: sha256:6191e4e158cdb5706af0fa4ee2103e8af2f0ad61845fb676b8fadd8c5a125b58
-generated: "2025-06-30T15:07:30.53240528+06:00"
+digest: sha256:8a74aad865557c045765dca5509fc33ce2a0f2a075d2b08ebf1489fe06c379cf
+generated: "2025-06-30T16:20:46.404313402Z"

--- a/charts/kubestash/Chart.yaml
+++ b/charts/kubestash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: KubeStash by AppsCode - Backup your Kubernetes native applications
 name: kubestash
 type: application
-version: v2025.4.30
-appVersion: v2025.4.30
+version: v2025.6.30
+appVersion: v2025.6.30
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/kubestash/stash-icon.png
 sources:
@@ -15,15 +15,15 @@ dependencies:
 - name: kubestash-operator
   repository: file://../kubestash-operator
   condition: kubestash-operator.enabled
-  version: v0.18.0
+  version: v0.19.0
 - name: kubestash-catalog
   repository: file://../kubestash-catalog
   condition: kubestash-catalog.enabled
-  version: v2025.4.30
+  version: v2025.6.30
 - name: kubestash-metrics
   repository: file://../kubestash-metrics
   condition: kubestash-metrics.enabled
-  version: v2025.4.30
+  version: v2025.6.30
 - name: ace-user-roles
   repository: oci://ghcr.io/appscode-charts
   condition: ace-user-roles.enabled

--- a/charts/kubestash/README.md
+++ b/charts/kubestash/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubestash --version=v2025.4.30
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.4.30
+$ helm search repo appscode/kubestash --version=v2025.6.30
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.6.30
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys Backup operator on a [Kubernetes](http://kubernetes.io) clust
 To install/upgrade the chart with the release name `kubestash`:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.4.30
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.6.30
 ```
 
 The command deploys Backup operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -78,12 +78,12 @@ The following table lists the configurable parameters of the `kubestash` chart a
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.4.30 --set global.registry=stashed
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.6.30 --set global.registry=stashed
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.4.30 --values values.yaml
+$ helm upgrade -i kubestash appscode/kubestash -n kubestash --create-namespace --version=v2025.6.30 --values values.yaml
 ```


### PR DESCRIPTION
ProductLine: KubeStash
Release: v2025.6.30
Release-tracker: https://github.com/kubestash/CHANGELOG/pull/31
Signed-off-by: 1gtm <1gtm@appscode.com>