### PR TITLE
Add audit-token-requester ClusterRoleBinding to charts

### DIFF
--- a/charts/kubestash-operator/templates/license/audit-token-requester-cluster-role-binding.yaml
+++ b/charts/kubestash-operator/templates/license/audit-token-requester-cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubestash-operator.fullname" . }}-audit-token-requester
+  labels:
+    {{- include "kubestash-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appscode:audit-token-requester
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubestash-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## Summary
- Add `audit-token-requester-cluster-role-binding.yaml` to `kubestash-operator` chart
- Binds the chart's ServiceAccount to the `appscode:audit-token-requester` ClusterRole