### PR TITLE
Build kubestash-certified dependencies in update-chart-dependencies.sh

### DIFF
--- a/hack/scripts/update-chart-dependencies.sh
+++ b/hack/scripts/update-chart-dependencies.sh
@@ -19,3 +19,4 @@ set -e
 helm repo add appscode https://charts.appscode.com/stable/ || true
 
 helm dependency update charts/kubestash
+helm dependency update charts/kubestash-certified


### PR DESCRIPTION
Follow-up to #355.

#355 gitignored the vendored subchart archives under `charts/kubestash-certified/charts` (matching `kubedb/installer`) so `verify-catalog` stops failing on non-reproducible `helm`-packaged `.tgz`. But `hack/scripts/update-chart-dependencies.sh` only built the umbrella chart's dependencies:

```
helm dependency update charts/kubestash
```

So after the merge, the **OCI publish** job failed because the certified chart's `charts/` directory was empty:

```
Error: found in Chart.yaml, but missing in charts/ directory: kubestash-operator, kubestash-catalog, kubestash-metrics, ace-user-roles, taskqueue
```

Fix: also build the certified chart's dependencies, matching `kubedb/installer` (whose script builds `charts/kubedb-certified`):

```
helm dependency update charts/kubestash
helm dependency update charts/kubestash-certified
```

Verified locally: after running the updated script, `charts/kubestash-certified/charts/` is repopulated and `helm package charts/kubestash-certified` succeeds.