### PR TITLE
rbac: let the operator read and manage KubeVirt resources

### DIFF
--- a/charts/kubestash-operator/templates/rbac/cluster_role.yaml
+++ b/charts/kubestash-operator/templates/rbac/cluster_role.yaml
@@ -28,6 +28,51 @@ rules:
     resources:
       - solropsrequests
     verbs: ["get", "create", "patch", "delete"]
+  # KubeVirt VirtualMachine backup/restore.
+  #
+  # Two separate needs are covered here. First, the operator resolves a
+  # BackupConfiguration target by GETting it (pkg/target/target.go) through its
+  # cached client, so list and watch are required alongside get; without them
+  # the target check fails with Forbidden rather than NotFound and the
+  # BackupConfiguration never becomes Ready. Second, the operator creates the
+  # backup/restore job ClusterRoles that grant these same permissions to the
+  # addon's ServiceAccount, and RBAC forbids granting permissions the granter
+  # does not hold — so this list must remain a superset of the KubeVirt rules in
+  # the operator's pkg/rbac backup and restore job roles.
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+    verbs: ["get", "list", "watch", "create", "update"]
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachineinstances
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - snapshot.kubevirt.io
+    resources:
+      - virtualmachinesnapshots
+      - virtualmachinesnapshotcontents
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datavolumes
+    verbs: ["get", "list", "create"]
+  - apiGroups:
+      - instancetype.kubevirt.io
+    resources:
+      - virtualmachineinstancetypes
+      - virtualmachineclusterinstancetypes
+      - virtualmachinepreferences
+      - virtualmachineclusterpreferences
+    verbs: ["get", "list"]
+  - apiGroups:
+      - apps
+    resources:
+      - controllerrevisions
+    verbs: ["get", "list", "create"]
   - apiGroups:
       - storage.kubestash.com
     resources:

--- a/charts/kubestash-operator/templates/rbac/cluster_role.yaml
+++ b/charts/kubestash-operator/templates/rbac/cluster_role.yaml
@@ -28,17 +28,8 @@ rules:
     resources:
       - solropsrequests
     verbs: ["get", "create", "patch", "delete"]
-  # KubeVirt VirtualMachine backup/restore.
-  #
-  # Two separate needs are covered here. First, the operator resolves a
-  # BackupConfiguration target by GETting it (pkg/target/target.go) through its
-  # cached client, so list and watch are required alongside get; without them
-  # the target check fails with Forbidden rather than NotFound and the
-  # BackupConfiguration never becomes Ready. Second, the operator creates the
-  # backup/restore job ClusterRoles that grant these same permissions to the
-  # addon's ServiceAccount, and RBAC forbids granting permissions the granter
-  # does not hold — so this list must remain a superset of the KubeVirt rules in
-  # the operator's pkg/rbac backup and restore job roles.
+  # KubeVirt VirtualMachine backup/restore: read access resolves the target, and the
+  # rest must stay a superset of the pkg/rbac job roles the operator grants.
   - apiGroups:
       - kubevirt.io
     resources:


### PR DESCRIPTION
## Problem

A `BackupConfiguration` whose target is a KubeVirt `VirtualMachine` never becomes `Ready`, and once that is fixed its `BackupSession` fails before any job is created. Two distinct RBAC gaps on the operator's own ServiceAccount:

**1. Target resolution.** The operator resolves a target by GETting it as an unstructured object (`pkg/target/target.go:Exists`), through its cached client — so `list` and `watch` are needed alongside `get`. A Forbidden is not a NotFound, so `Exists` returns an *error* rather than reporting the target as absent, and the BackupConfiguration requeues forever with `targetFound` unset.

**2. Delegating to addon jobs.** The operator creates the `kubestash-backup-job` / `kubestash-restore-job` ClusterRoles that grant the addon's ServiceAccount its permissions. Kubernetes RBAC forbids granting permissions the granter does not hold, so every KubeVirt rule the operator writes into those roles it must also hold. Without that, the BackupSession fails at:

```
failed to ensure backup job rbac: clusterroles.rbac.authorization.k8s.io
"kubestash-backup-job" is forbidden: user "system:serviceaccount:stash:kubestash-kubestash-operator"
is attempting to grant RBAC permissions not currently held:
{APIGroups:["snapshot.kubevirt.io"], Resources:["virtualmachinesnapshots"], ...}
{APIGroups:["cdi.kubevirt.io"], Resources:["datavolumes"], ...}
{APIGroups:["instancetype.kubevirt.io"], ...}
{APIGroups:["apps"], Resources:["controllerrevisions"], ...}
```

## Fix

Add the KubeVirt rules to the operator ClusterRole as a **superset** of the KubeVirt rules in the operator's `pkg/rbac` backup and restore job roles:

- `kubevirt.io/virtualmachines` — get, list, watch, create, update (create/update for restore)
- `kubevirt.io/virtualmachineinstances` — get, list, watch
- `snapshot.kubevirt.io/virtualmachinesnapshots{,contents}` — get, list, watch, create, delete
- `cdi.kubevirt.io/datavolumes` — get, list, create
- `instancetype.kubevirt.io` instancetypes/preferences, namespaced and cluster-scoped — get, list
- `apps/controllerrevisions` — get, list, create

The comment in the template records the superset constraint so the two lists do not drift.

## Verification

Deployed on a k3s test cluster (KubeVirt v1.8.4, CDI v1.65.0, TopoLVM) via `helm upgrade` of this chart, paired with the operator-side rules in kubestash/kubestash (branch `kubevirt`), and with all previously hand-applied ClusterRoles **deleted** from the cluster:

- BackupConfiguration → `Ready`, `targetFound: true`
- BackupSession → Snapshot `Succeeded`, `integrity: true`, components `manifest` + `volume-vmtest-root` + `volume-vmtest-data`
- RestoreSession → `Succeeded`; VM, both DataVolumes, both PVCs, Secrets, ConfigMap and ServiceAccount restored, disk contents verified by sha256 round-trip against the pre-backup values
- The generated `kubestash-backup-job` / `kubestash-restore-job` roles carry the expected KubeVirt rules, the restore one including `create`/`update` on virtualmachines

## Related

- kubestash/kubestash — operator-side `pkg/rbac` rules plus the restore task-ordering fix (branch `kubevirt`)
- kubestash/kubevirt#1 — the KubeVirt VirtualMachine backup & restore addon plugin
